### PR TITLE
[FE] 시간별 소비량 분석 페이지 만들기

### DIFF
--- a/app/analyze/components/charts/hourly-amount-average-chart.tsx
+++ b/app/analyze/components/charts/hourly-amount-average-chart.tsx
@@ -1,0 +1,167 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { X, Edit, BarChart3 } from "lucide-react"
+import { useSessionStore } from "@/store/useSessionStore"
+import {
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  Legend,
+} from "recharts"
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart"
+
+interface HourlyAmountAverageChartProps {
+  filters: any
+  isEditMode: boolean
+  analysisMode: "individual" | "collective"
+  isLoading: boolean
+  onRemove: () => void
+  onEdit: () => void
+}
+
+interface ApiDataItem {
+  hour: number
+  avgSpentAmount: number
+  avgIncomeAmount: number
+}
+
+export default function HourlyAmountAverageChart({
+  filters,
+  isEditMode,
+  analysisMode,
+  isLoading,
+  onRemove,
+  onEdit,
+}: HourlyAmountAverageChartProps) {
+  const sessionId = useSessionStore((state) => state.sessionId)
+  const [data, setData] = useState<ApiDataItem[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!sessionId || !filters?.dateRange?.start || !filters?.dateRange?.end) return
+      setLoading(true)
+      try {
+        const res = await fetch(
+          `http://localhost:8080/api/analysis/hour-amount-average?sessionId=${sessionId}&durationStart=${filters.dateRange.start}&durationEnd=${filters.dateRange.end}`
+        )
+        const json = await res.json()
+        setData(Array.isArray(json?.result?.data) ? json.result.data : [])
+      } catch (err) {
+        console.error("시간별 평균 거래금액 데이터 로드 실패", err)
+        setData([])
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchData()
+  }, [sessionId, filters?.dateRange?.start, filters?.dateRange?.end])
+
+  const chartData: ApiDataItem[] = Array(24)
+    .fill(null)
+    .map((_, hour) => {
+      const found = data.find((d) => d.hour === hour)
+      return {
+        hour,
+        avgSpentAmount: found?.avgSpentAmount ?? 0,
+        avgIncomeAmount: found?.avgIncomeAmount ?? 0,
+      }
+    })
+
+  if (isLoading) {
+    return (
+      <Card className="h-full">
+        <CardContent className="flex items-center justify-center h-[400px]">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card className="h-full">
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle className="flex items-center gap-2">
+          <BarChart3 className="h-5 w-5" />📊 시간대별 평균 거래금액
+        </CardTitle>
+        {isEditMode && (
+          <div className="flex gap-1">
+            <Button variant="ghost" size="sm" onClick={onEdit}>
+              <Edit className="h-4 w-4" />
+            </Button>
+            <Button variant="ghost" size="sm" onClick={onRemove}>
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+        )}
+      </CardHeader>
+      <CardContent>
+        <ChartContainer
+          config={{
+            avgSpentAmount: {
+              label: "평균 지출",
+              color: "hsl(var(--chart-1))",
+            },
+            avgIncomeAmount: {
+              label: "평균 수입",
+              color: "hsl(var(--chart-2))",
+            },
+          }}
+          className="h-[350px]"
+        >
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={chartData}
+              margin={{ top: 20, right: 30, left: 20, bottom: 5 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis
+                dataKey="hour"
+                tickFormatter={(hour) => `${hour}시`}
+                interval={0}
+              />
+              <YAxis
+                tickFormatter={(value) =>
+                  value >= 10000
+                    ? `${(value / 10000).toFixed(0)}만`
+                    : value.toString()
+                }
+              />
+              <ChartTooltip
+                content={<ChartTooltipContent />}
+                formatter={(value: number, name: string) => [
+                  value.toLocaleString(),
+                  name === "avgSpentAmount" ? "평균 지출" : "평균 수입",
+                ]}
+              />
+              <Legend />
+              <Bar
+                dataKey="avgSpentAmount"
+                fill="var(--color-chart-1)"
+                name="평균 지출"
+                radius={[4, 4, 0, 0]}
+              />
+              <Bar
+                dataKey="avgIncomeAmount"
+                fill="var(--color-chart-2)"
+                name="평균 수입"
+                radius={[4, 4, 0, 0]}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/analyze/components/widget-grid.tsx
+++ b/app/analyze/components/widget-grid.tsx
@@ -11,6 +11,7 @@ import BalanceTrendChart from "./charts/balance-trend-chart"
 import CategoryPieChart from "./charts/category-pie-chart"
 import CollectiveComparisonChart from "./charts/collective-comparison-chart"
 import TopCategoriesChart from "./charts/top-categories-chart"
+import HourlyAmountAverageChart from "./charts/hourly-amount-average-chart"
 import WidgetSelector from "./widget-selector"
 import ChartEditModal from "./chart-edit-modal"
 
@@ -31,6 +32,7 @@ export default function WidgetGrid({ isEditMode, filters, analysisMode, isLoadin
     { id: "daily-comparison", type: "daily-comparison", position: { x: 0, y: 2 }, size: { w: 2, h: 1 } },
     { id: "weekly-comparison", type: "weekly-comparison", position: { x: 2, y: 1 }, size: { w: 2, h: 1 } },
     { id: "heatmap-chart", type: "heatmap-chart", position: { x: 2, y: 2 }, size: { w: 2, h: 1 } },
+    { id: "hourly-amount-average", type: "hourly-amount-average", position: { x: 0, y: 0 }, size: { w: 2, h: 1 } },
   ])
 
   const [editingWidget, setEditingWidget] = useState<string | null>(null)
@@ -109,13 +111,15 @@ export default function WidgetGrid({ isEditMode, filters, analysisMode, isLoadin
         return <CollectiveComparisonChart {...commonProps} />
       case "top-categories":
         return <TopCategoriesChart {...commonProps} />
+      case "hourly-amount-average":
+        return <HourlyAmountAverageChart {...commonProps} />
       default:
         return null
     }
   }
 
   return (
-    <div ref={drop} className="relative">
+    <div ref={drop as unknown as React.LegacyRef<HTMLDivElement>} className="relative">
       {isEditMode && <WidgetSelector onAddWidget={addWidget} />}
 
       <div className="grid grid-cols-4 gap-6 auto-rows-fr">

--- a/app/analyze/components/widget-selector.tsx
+++ b/app/analyze/components/widget-selector.tsx
@@ -2,7 +2,7 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { Plus, BarChart3, TrendingUp, PieChart, Users, List, CalendarDays } from "lucide-react"
+import { Plus, BarChart3, TrendingUp, PieChart, Users, List, CalendarDays, Heater } from "lucide-react"
 
 interface WidgetSelectorProps {
   onAddWidget: (type: string) => void
@@ -17,7 +17,8 @@ export default function WidgetSelector({ onAddWidget }: WidgetSelectorProps) {
     { type: "category-pie", name: "카테고리별 지출 비중", icon: PieChart },
     { type: "collective-comparison", name: "집단 평균 비교", icon: Users },
     { type: "top-categories", name: "상위 소비 카테고리", icon: List },
-    { type: "heatmap-chart", name: "요일-시간별 트랜잭션 밀도", icon: Heatmap },
+    { type: "heatmap-chart", name: "요일-시간별 트랜잭션 밀도", icon: Heater },
+    { type: "hourly-amount-average", name: "hourly-amount-average", icon:TrendingUp},
   ]
 
   return (


### PR DESCRIPTION
시간별 소비량을 분석하는 페이지 구현

## 변경점
1. hourly-amount-average-chart.tsx 컴포넌트 추가
2. widget-grid와 widget-selector에 hourly-amount-average-char 정보 추가
 
## 체크리스트
- [x] 무엇을 변경했는지 설명

## 관련 이슈
- Closes #10 